### PR TITLE
Add wandb logging support across training scripts and enhance API key…

### DIFF
--- a/scripts/jobs/_job_common.sh
+++ b/scripts/jobs/_job_common.sh
@@ -124,6 +124,17 @@ check_wandb_api_key() {
   fi
 }
 
+require_wandb_api_key() {
+  # Fail if WANDB_API_KEY is not set (for jobs that require wandb logging)
+  if [[ -z "${WANDB_API_KEY:-}" ]]; then
+    echo "ERROR: WANDB_API_KEY is required but not set." >&2
+    echo "       Set it in .env or export before submitting jobs." >&2
+    echo "       Example: export WANDB_API_KEY=your_api_key_here" >&2
+    return 1
+  fi
+  echo "WANDB_API_KEY: set (wandb logging enabled)"
+}
+
 load_and_require_asvspoof5_root() {
   load_dotenv_if_present
   require_env_var "ASVSPOOF5_ROOT"

--- a/scripts/jobs/run_baselines.job
+++ b/scripts/jobs/run_baselines.job
@@ -45,6 +45,9 @@ echo ""
 source scripts/jobs/_job_common.sh
 load_and_require_asvspoof5_root
 
+# Optional defaults
+export WANDB_PROJECT=${WANDB_PROJECT:-asvspoof5-dann}
+
 echo "=== Running Non-Semantic Baselines ==="
 
 # Extract LFCC features
@@ -56,7 +59,7 @@ srun uv run python scripts/extract_lfcc.py --split dev
 # Train LFCC-GMM
 echo ""
 echo "--- Training LFCC-GMM ---"
-srun uv run python scripts/train_lfcc_gmm.py --n-components 32
+srun uv run python scripts/train_lfcc_gmm.py --n-components 32 --wandb
 
 # Extract TRILLsson embeddings (if TensorFlow Hub is available)
 echo ""
@@ -68,8 +71,8 @@ srun uv run python scripts/extract_trillsson.py --split dev || echo "TRILLsson e
 if [ -f "data/features/trillsson/train.npy" ]; then
     echo ""
     echo "--- Training TRILLsson Classifier ---"
-    srun uv run python scripts/train_trillsson.py --classifier logistic
-    srun uv run python scripts/train_trillsson.py --classifier mlp
+    srun uv run python scripts/train_trillsson.py --classifier logistic --wandb
+    srun uv run python scripts/train_trillsson.py --classifier mlp --wandb
 else
     echo "Skipping TRILLsson classifier (embeddings not found)"
 fi

--- a/scripts/run_held_out_codec.py
+++ b/scripts/run_held_out_codec.py
@@ -235,6 +235,8 @@ def run_held_out_experiment(
     output_dir: Path,
     seed: int,
     skip_training: bool = False,
+    use_wandb: bool = False,
+    wandb_project: str = "asvspoof5-held-out",
 ) -> dict:
     """Run a single held-out codec experiment.
 
@@ -244,6 +246,8 @@ def run_held_out_experiment(
         output_dir: Output directory for this experiment.
         seed: Random seed.
         skip_training: If True, skip training and load existing checkpoints.
+        use_wandb: Whether to enable wandb logging.
+        wandb_project: Wandb project name.
 
     Returns:
         Dictionary with results for this held-out codec.
@@ -446,6 +450,12 @@ def run_held_out_experiment(
                 gradient_clip=config["training"].get("gradient_clip", 1.0),
                 use_amp=config["training"].get("use_amp", False),
                 lambda_scheduler=lambda_scheduler,
+                use_wandb=use_wandb,
+                wandb_project=wandb_project,
+                wandb_run_name=f"held_out_{held_out_codec}_{method}",
+                wandb_tags=["held-out", held_out_codec, method],
+                codec_vocab=codec_vocab,
+                codec_q_vocab=codec_q_vocab,
             )
 
             trainer.train()
@@ -599,6 +609,8 @@ def main():
             output_dir=output_dir,
             seed=args.seed,
             skip_training=args.skip_training,
+            use_wandb=args.wandb,
+            wandb_project=args.wandb_project,
         )
         all_results.append(result)
 


### PR DESCRIPTION
… validation

- Introduced `require_wandb_api_key` function in `_job_common.sh` to ensure WANDB_API_KEY is set for jobs requiring wandb logging.
- Updated `train_trillsson.py` and `train_lfcc_gmm.py` to include command-line arguments for enabling wandb logging and specifying the project name.
- Implemented wandb logging in the training loops, capturing metrics and handling potential logging failures.
- Modified job scripts to utilize the new wandb options during training runs.